### PR TITLE
v1.1.3 Pin transitive dependencies for scanner

### DIFF
--- a/src/AspNetCore.HealthChecks.Configuration/AspNetCore.HealthChecks.Configuration.csproj
+++ b/src/AspNetCore.HealthChecks.Configuration/AspNetCore.HealthChecks.Configuration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Description>A health check to verify configuration values.</Description>
     <Authors>Ritter Insurance Marketing</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/AspNetCore.HealthChecks.Configuration.Tests/AspNetCore.HealthChecks.Configuration.Tests.csproj
+++ b/tests/AspNetCore.HealthChecks.Configuration.Tests/AspNetCore.HealthChecks.Configuration.Tests.csproj
@@ -20,6 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- pinned transitive dependencies to satisfy SNYK, these could be removed once the direct dependency is updated -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> <!-- via: Microsoft.NET.Test.Sdk -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" /> <!-- via: xunit 2.4.1 -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" /> <!-- via: Microsoft.NET.Test.Sdk -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our code does not take a direct dependency on the vulnerable versions,
but some of our dependencies have them in their dependencies.